### PR TITLE
Changes to deal with more strict tag parsing

### DIFF
--- a/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page1.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page1.playgroundpage/Contents.swift
@@ -13,10 +13,5 @@ playgroundPrologue()
 display.show(text: "/*#-editable-code*/<#T##string##String#>/*#-end-editable-code*/")
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramOutputString.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page2.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page2.playgroundpage/Contents.swift
@@ -13,10 +13,5 @@ playgroundPrologue()
 display.show(number: /*#-editable-code*/<#T##number##UInt#>/*#-end-editable-code*/)
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramOutputNumber.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page3.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page3.playgroundpage/Contents.swift
@@ -16,11 +16,6 @@ playgroundPrologue()
 display.show(image: /*#-editable-code*/.<#T##miniImage##miniImage#>/*#-end-editable-code*/)
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramOutputImage.assessment )
 //#-end-hidden-code
 

--- a/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page4.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page4.playgroundpage/Contents.swift
@@ -19,10 +19,5 @@ display.show(grid: [
 ])
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramOutputGrid.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page5.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page5.playgroundpage/Contents.swift
@@ -15,10 +15,5 @@ playgroundPrologue()
 rgb.on(color: /*#-editable-code*/.<#T##miniColor##miniColor#>/*#-end-editable-code*/)
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramOutputRGB.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page6.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page6.playgroundpage/Contents.swift
@@ -15,10 +15,5 @@ playgroundPrologue()
 sound.on(note: /*#-editable-code*/.<#T##miniSound##miniSound#>/*#-end-editable-code*/)
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramOutputSound.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page7.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter1.playgroundchapter/Pages/Page7.playgroundpage/Contents.swift
@@ -24,11 +24,6 @@ rgb.on(color: /*#-editable-code*/.<#T##miniColor##miniColor#>/*#-end-editable-co
 display.show(text: "/*#-editable-code*/<#T##string##String#>/*#-end-editable-code*/")
 display.show(image: /*#-editable-code*/.<#T##miniImage##miniImage#>/*#-end-editable-code*/)
 
-//#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
 
 //#-hidden-code
 playgroundEpilogue( BookProgramOutputCombination.assessment )

--- a/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page1.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page1.playgroundpage/Contents.swift
@@ -18,10 +18,5 @@ func onButtonA() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramInputButtonA.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page2.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page2.playgroundpage/Contents.swift
@@ -18,10 +18,5 @@ func onButtonB() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramInputButtonB.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page3.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page3.playgroundpage/Contents.swift
@@ -18,10 +18,5 @@ func onButtonAB() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramInputButtonAB.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page4.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page4.playgroundpage/Contents.swift
@@ -18,10 +18,5 @@ func onPin(pin:UInt16) {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramInputPin.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page5.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page5.playgroundpage/Contents.swift
@@ -15,10 +15,5 @@ func onShake() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramInputShake.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page6.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter2.playgroundchapter/Pages/Page6.playgroundpage/Contents.swift
@@ -57,10 +57,5 @@ func onPin(pin: UInt16) {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramInputCombination.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page1.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page1.playgroundpage/Contents.swift
@@ -15,10 +15,5 @@ func start() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramCommandStart.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page2.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page2.playgroundpage/Contents.swift
@@ -20,10 +20,5 @@ func start() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramCommandSleep.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page3.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page3.playgroundpage/Contents.swift
@@ -20,10 +20,5 @@ func start() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramCommandClear.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page4.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page4.playgroundpage/Contents.swift
@@ -21,10 +21,5 @@ func forever() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramCommandForever.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page5.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page5.playgroundpage/Contents.swift
@@ -19,10 +19,5 @@ func start() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramCommandVariables.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page6.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page6.playgroundpage/Contents.swift
@@ -21,10 +21,5 @@ func start() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramCommandLoops.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page7.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page7.playgroundpage/Contents.swift
@@ -16,10 +16,5 @@ func onShake() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramCommandRandom.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page8.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page8.playgroundpage/Contents.swift
@@ -21,10 +21,5 @@ func onShake() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramCommandConditionals.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page9.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter3.playgroundchapter/Pages/Page9.playgroundpage/Contents.swift
@@ -83,10 +83,5 @@ func forever() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramCommandCombination.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page1.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page1.playgroundpage/Contents.swift
@@ -24,10 +24,5 @@ func onShake() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramProjectDice.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page2.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page2.playgroundpage/Contents.swift
@@ -30,10 +30,5 @@ func forever() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramProjectRockPaperScissors.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page3.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page3.playgroundpage/Contents.swift
@@ -36,10 +36,5 @@ func forever() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramProjectPiano.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page4.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page4.playgroundpage/Contents.swift
@@ -33,10 +33,5 @@ func forever() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramProjectClap.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page5.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page5.playgroundpage/Contents.swift
@@ -24,10 +24,5 @@ func forever() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramProjectTheremin.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page6.playgroundpage/Contents.swift
+++ b/PlaygroundBook/Chapters/Chapter4.playgroundchapter/Pages/Page6.playgroundpage/Contents.swift
@@ -31,10 +31,5 @@ func forever() {
 }
 
 //#-hidden-code
-//#-editable-code Tap to write your code
-//#-end-editable-code
-//#-end-hidden-code
-
-//#-hidden-code
 playgroundEpilogue( BookProgramProjectThermometer.assessment )
 //#-end-hidden-code

--- a/PlaygroundBook/PrivateResources/Base.lproj/DashBoardConfigurationViewController.xib
+++ b/PlaygroundBook/PrivateResources/Base.lproj/DashBoardConfigurationViewController.xib
@@ -213,11 +213,13 @@
             </subviews>
             <constraints>
                 <constraint firstItem="8Mg-uQ-ymC" firstAttribute="top" secondItem="Jtp-F2-msj" secondAttribute="top" id="0xa-tW-6uh"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="8Mg-uQ-ymC" secondAttribute="trailing" id="3ZA-gc-shh"/>
                 <constraint firstAttribute="bottom" secondItem="PqA-Zc-6Vr" secondAttribute="bottom" priority="999" id="3aq-Jl-3qV"/>
                 <constraint firstAttribute="leading" secondItem="8Mg-uQ-ymC" secondAttribute="leading" id="EHw-Xa-gNm"/>
                 <constraint firstItem="PqA-Zc-6Vr" firstAttribute="leading" secondItem="Jtp-F2-msj" secondAttribute="leading" id="PYM-Ap-fPZ"/>
                 <constraint firstAttribute="trailing" secondItem="PqA-Zc-6Vr" secondAttribute="trailing" priority="999" id="QFu-Ko-Jon"/>
                 <constraint firstItem="8Mg-uQ-ymC" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="Ded-2l-SCP" secondAttribute="leading" priority="754" constant="-8" id="Zae-LS-GGR"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="8Mg-uQ-ymC" secondAttribute="bottom" id="ryY-JU-sHf"/>
                 <constraint firstItem="PqA-Zc-6Vr" firstAttribute="top" secondItem="Jtp-F2-msj" secondAttribute="top" id="x4t-Ms-cbg"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>

--- a/PlaygroundBook/PrivateResources/Base.lproj/MatrixConnectionViewController.xib
+++ b/PlaygroundBook/PrivateResources/Base.lproj/MatrixConnectionViewController.xib
@@ -108,11 +108,13 @@
             </subviews>
             <constraints>
                 <constraint firstItem="gsw-XM-54G" firstAttribute="top" secondItem="zs4-zm-gk9" secondAttribute="top" id="7rf-1A-RoD"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="zs4-zm-gk9" secondAttribute="bottom" id="AOm-rV-gPJ"/>
                 <constraint firstItem="zs4-zm-gk9" firstAttribute="trailing" secondItem="gsw-XM-54G" secondAttribute="trailing" id="ND3-X5-obv"/>
                 <constraint firstItem="zs4-zm-gk9" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="PAp-vc-EJH"/>
                 <constraint firstAttribute="bottom" secondItem="gsw-XM-54G" secondAttribute="bottom" priority="999" id="PbS-RY-Jrc"/>
                 <constraint firstItem="gsw-XM-54G" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" priority="999" id="QsD-an-4u5"/>
                 <constraint firstItem="zs4-zm-gk9" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="NBD-O3-ICc" secondAttribute="trailing" priority="755" constant="8" id="UPF-6s-f2d"/>
+                <constraint firstItem="zs4-zm-gk9" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="nAC-AS-hBZ"/>
                 <constraint firstAttribute="trailing" secondItem="zs4-zm-gk9" secondAttribute="trailing" id="qcz-nd-m3k"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>

--- a/PlaygroundBook/Sources/GeneralUtilities/Ext.swift
+++ b/PlaygroundBook/Sources/GeneralUtilities/Ext.swift
@@ -7,6 +7,17 @@
 
 import UIKit
 
+extension Array where Element: Equatable {
+
+	// Remove first collection element that is equal to the given `object`:
+	mutating func remove(object: Element) -> Element? {
+		if let index = index(of: object) {
+			return remove(at: index)
+		}
+		return nil
+	}
+}
+
 extension Character {
 	var ascii: UInt8 {
 		return UInt8(String(self).unicodeScalars.first!.value)

--- a/PlaygroundBook/Sources/LiveView/Auxiliary/Extension_NotificationCenter.swift
+++ b/PlaygroundBook/Sources/LiveView/Auxiliary/Extension_NotificationCenter.swift
@@ -27,17 +27,6 @@ extension NotificationCenter {
     }
 }
 
-extension Array where Element: Equatable {
-    
-    // Remove first collection element that is equal to the given `object`:
-    mutating func remove(object: Element) -> Element? {
-        if let index = index(of: object) {
-            return remove(at: index)
-        }
-        return nil
-    }
-}
-
 //MARK: observe all
 class NotificationCenterCatchAll {
     private static var catchAllTocken:NotificationToken?


### PR DESCRIPTION
There was one hidden editable region in each chapter from 1 through 4. In the past, those were just ignored by the parsers, but since iOS 12.4 (or 13.0) errors about not properly nested tags appeared. The hidden editable regions were superfluous and could thus be deleted, which solved the problem.